### PR TITLE
Fix bgzf block size calculation

### DIFF
--- a/src/bgzf.js
+++ b/src/bgzf.js
@@ -61,7 +61,7 @@ function unbgzf(data, lim) {
 
 function bgzBlockSize(data) {
     const ba = new Uint8Array(data);
-    const bsize = (ba[17] << 8) | (ba[16]) + 1;
+    const bsize = (ba[17] << 8 | ba[16]) + 1;
     return bsize;
 }
 


### PR DESCRIPTION
Block size calculation is wrong (see issue https://github.com/igvteam/igv.js/issues/1280). This seems to cause entire blocks not being loaded as they should.

Demonstration:
![image](https://user-images.githubusercontent.com/4920368/110334204-ca86b000-8022-11eb-9773-c7b458913c0c.png)
