### PR TITLE
Replace gapi check with oauth initialization check

### DIFF
--- a/src/igvxhr.js
+++ b/src/igvxhr.js
@@ -247,7 +247,7 @@ class IGVXhr {
                     }
                 } else if (xhr.status === 416) {
                     handleError(Error(`416 Unsatisfiable Range`))
-                } else if ((typeof gapi !== "undefined") &&
+                } else if (GoogleAuth.isInitialized() &&
                     ((xhr.status === 404 || xhr.status === 401 || xhr.status === 403) &&
                         GoogleUtils.isGoogleURL(url)) &&
                     !options.retries) {


### PR DESCRIPTION
Having this check requires the users to import the gapi script unnecessarily (the script also shows
deprecation warnings in the console now). Replacing this check is enough to not need gapi anymore.
